### PR TITLE
Extract Log file and overwriteIniFile reworks; variables for extract and activity target location

### DIFF
--- a/src/windowManager/EvalIniDialog.java
+++ b/src/windowManager/EvalIniDialog.java
@@ -73,7 +73,7 @@ public class EvalIniDialog extends JDialog {
 	 */
 	public EvalIniDialog(iniFile ini) {
 		
-		setBounds(100, 100, 819, 408);
+		setBounds(100, 100, 819, 477);
 		getContentPane().setLayout(new BorderLayout());
 		contentPanel.setBorder(new EmptyBorder(5, 5, 5, 5));
 		getContentPane().add(contentPanel, BorderLayout.CENTER);
@@ -268,14 +268,14 @@ public class EvalIniDialog extends JDialog {
 		contentPanel.add(lblUsedIniFile);
 		
 		tfIniFilePath = new JLabel();
-		tfIniFilePath.setBounds(95, 195, 368, 20);
+		tfIniFilePath.setBounds(79, 195, 368, 20);
 		contentPanel.add(tfIniFilePath);
 		if (ini._pathToIniFile == null) {tfIniFilePath.setText("no ini file was found or it cannot be loaded");
 		} else {tfIniFilePath.setText(""+ini._pathToIniFile);			
 		}
 		
 		JButton btnBrowse = new JButton("Browse");
-		btnBrowse.setBounds(473, 194, 89, 23);
+		btnBrowse.setBounds(456, 194, 89, 23);
 		contentPanel.add(btnBrowse);
 				
 		btnBrowse.addActionListener(new ActionListener() {
@@ -284,6 +284,8 @@ public class EvalIniDialog extends JDialog {
 				//Create a file chooser
 		        final JFileChooser fileDialog = new JFileChooser();
 		        
+		        //name of the filechooser window
+		        fileDialog.setDialogTitle("Choose ini file (.ini):");
 		        //only show not hidden files
 		        fileDialog.setFileHidingEnabled(true);
 		        
@@ -291,7 +293,7 @@ public class EvalIniDialog extends JDialog {
 		        //fileDialog.setCurrentDirectory(System.getProperty("user.dir"));
 		        
 		       
-		        //to select mulitple files
+		        //to select single file
 		        fileDialog.setMultiSelectionEnabled(false);
 		        //In response to a button click:
 		        int option = fileDialog.showOpenDialog(null);
@@ -305,12 +307,10 @@ public class EvalIniDialog extends JDialog {
 	               		//passing file to the ini method
 	               		try {
 	               			ini.loadIniFile(file); //= new iniFile(file);
-	               			System.out.println(""+ini._pathToIniFile);
 	               			dispose();
 	               			EvalIniDialog dialog = new EvalIniDialog(ini);
 	               			dialog.setVisible(true);
 	               			System.out.println("Trying to refresh the window");
-	               			System.out.println(""+ini._pathToIniFile);
 	               			
 	               		} catch (Exception e) {// somewhere here is an error, I don't know where
 	               			// TODO Auto-generated catch block
@@ -356,6 +356,24 @@ public class EvalIniDialog extends JDialog {
 		tfBrowsedDataPath.setText(ini.lvl2);
 		contentPanel.add(tfBrowsedDataPath);
 		
+		JLabel lblextractFileFolder = new JLabel("Folder to save extract (.txt) file:");
+		lblextractFileFolder.setBounds(10, 327, 301, 16);
+		contentPanel.add(lblextractFileFolder);	
+		
+		JTextField tfextractFileFolder = new JTextField();
+		tfextractFileFolder.setBounds(10, 342, 368, 16);
+		tfextractFileFolder.setText(ini.extractFileFolder);
+		contentPanel.add(tfextractFileFolder);
+
+		JLabel lblactivityFileFolder = new JLabel("Folder to save activity (.act) file:");
+		lblactivityFileFolder.setBounds(10, 362, 301, 16);
+		contentPanel.add(lblactivityFileFolder);	
+		
+		JTextField tfactivityFileFolder = new JTextField();
+		tfactivityFileFolder.setBounds(10, 376, 368, 16);
+		tfactivityFileFolder.setText(ini.activityFileFolder);
+		contentPanel.add(tfactivityFileFolder);
+		
 		{
 			JPanel buttonPane = new JPanel();
 			buttonPane.setLayout(new FlowLayout(FlowLayout.RIGHT));
@@ -368,7 +386,7 @@ public class EvalIniDialog extends JDialog {
 						try {
 							ini.overwriteIniFile(ini._pathToIniFile, tfMonitorID, tfNoiseThreshold, tfWindowThreshold, tfLowerFitThreshold, tfUpperFitThreshold, tfLowerFlagThreshold, 
 									tfUpperFlagThreshold, tfFluxslope, tfFluxoffset, tfSolidangle, tfDisequilibriumfactor, tfHoentzsch, tfInterval, tfEdgeoffset, tfIPAdress, tfFluxchannel, tfFiller, chckbxfillup,
-									tfRawDataPath,tfAtomaticDataPath,tfBrowsedDataPath
+									tfRawDataPath, tfAtomaticDataPath, tfBrowsedDataPath, tfextractFileFolder, tfactivityFileFolder
 									);
 							dispose();
 						} catch (Exception e1) {

--- a/src/windowManager/RnLog.java
+++ b/src/windowManager/RnLog.java
@@ -761,7 +761,6 @@ public class RnLog extends JFrame {
 		btnReadMemoryCard.setBounds(789, 276, 140, 23);
 		panel.add(btnReadMemoryCard);
 		
-		//TODO: change edge/spektrum with keys
         class MyDispatcher implements KeyEventDispatcher {
 			@Override
 		    public boolean dispatchKeyEvent(KeyEvent e) {
@@ -870,16 +869,7 @@ public class RnLog extends JFrame {
 		//Extract Spectra
 		mntmNewMenuItem_1.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent e) {
-				//PopUp to enter Name of *.ext file
-				//Select Spectra to extract
-				String extFilename = (String) JOptionPane.showInputDialog(null,"Enter a filename (*.txt):",
-                        "Creating Logfile",
-                        JOptionPane.PLAIN_MESSAGE, null, null, "extract.txt");
-				//if no filename was given or canceled:
-				if(extFilename == null || (extFilename != null && ("".equals(extFilename))))   {
-				    return;
-				}
-				System.out.println(extFilename);
+				
 				spectraList.clear();
 				//select spectra
 				chooseSpectraDialog(chartPanel);
@@ -887,88 +877,145 @@ public class RnLog extends JFrame {
 					//user cancelled operation
 					return;
 				}
-				//extract spectra from spectra list and write it into extFile
-				File extFile = null;
-				System.out.println(spectraList.get(0).path.getParent() + "\\" + extFilename);
-				extFile = new File(spectraList.get(0).path.getParent() + "\\" + extFilename);
-				FileOutputStream fileOut;
-				try {
-					fileOut = new FileOutputStream(extFile);
-			    	BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fileOut));
-			    	double progress = 0;
-			    	progressBar.setValue((int) (progress));
-			    	progressBar.setStringPainted(true);
-			    	//write first line
-			        bw.write("Date Time; Lifetime;ADC1; StdADC1; T1; StdT1;T2; StdT2;T3; StdT3;Rn1;Rn2;Rn3;Rn4;ADC2; StdADC2; ADC3; StdADC3; Counter1;Counter2;FluxSlope;FluxOffset;ADC2Slope;ADC2Offset;ADC3Slope;ADC3Offset;Temp1Slope;Temp1Offset;Temp2Slope;Temp2Offset;Temp3Slope;Temp3Offset;Counter1Slope;Counter1Offset;Counter2Slope;Counter2Offset;ID \r\n");
-			        //loop though the selected spectra, see if they need to be flagged
-			        int[] flaggedIdx = new int[spectraList.size()];
-			        for(int i=0; i<spectraList.size(); i++) {
-			        	//set edge of spectrum according to reference (if no edge is set yet)
-			        	spectraList.get(i).calcEdge(RefSpec, ini.thres3, ini.thres4, ini.Edgeoffset);
-			        	progress = (((double) i+1.0)/(spectraList.size())*100.0);
-			        	System.out.println( (progress));
-			        	progressBar.setValue((int) (progress));
-			        	//flag spectra
-			        	if(spectraList.get(i).edge > ini.Edgeoffset+ini.UpperFlagThres || spectraList.get(i).edge < ini.Edgeoffset-ini.LowerFlagThres) {
-			        		//save Spectrum in new subfolder \flagged
-			        		File tmpFlagged = new File( spectraList.get(i).path.getParent()+ "\\flagged\\" + spectraList.get(i).name);
-			        		copyFile(spectraList.get(i).path, tmpFlagged);
-			        		flaggedIdx[i]=1;
-			        		System.out.println("copied " + spectraList.get(i).path.getPath() + " to " + tmpFlagged.getPath() );
-			        		continue;
-			        	}
-			        	//TODO: berechnung der slopes und RNs
-			        	bw.write(spectraList.get(i).datetime + "; " +
-			        	spectraList.get(i).LT + "; " +
-			        	spectraList.get(i).ADC1 + "; "+
-			        	spectraList.get(i).ADC1StD + "; "+
-			        	spectraList.get(i).T1 + "; "+
-			        	spectraList.get(i).T1StD + "; "+
-			        	spectraList.get(i).T2 + "; "+
-			        	spectraList.get(i).T2StD + "; "+
-			        	spectraList.get(i).T3 + "; "+
-			        	spectraList.get(i).T3StD + "; "+
-			        	//RN1 in the old Delphi program, counts above the noise threshold (TotalThreshold)
-			        	spectraList.get(i).integrate(ini.thres1, 128) + "; "+			
-			        	//RN2 in the old Delphi, counts inside threshold window (between TotalThres and WindowThreshold)
-			        	spectraList.get(i).integrate(ini.thres1, ini.thres2) + "; "+		
-			        	//RN3 in the old Delphi, counts above the edge
-			        	spectraList.get(i).integrate(spectraList.get(i).edge, 128)+ "; "+		
-			        	//RN4 in the old Delphi
-			        	spectraList.get(i).edge + "; "+		
-			        	spectraList.get(i).ADC2 + "; "+
-			        	spectraList.get(i).ADC2StD + "; "+
-			        	spectraList.get(i).ADC3 + "; "+
-			        	spectraList.get(i).ADC3StD + "; "+
-			        	spectraList.get(i).counter1 + "; "+
-			        	spectraList.get(i).counter2 + "; "+
-			        	spectraList.get(i).fluxslope+ "; "+
-			        	spectraList.get(i).fluxoffset+ "; "+
-			        	spectraList.get(i).ADC2Slope+ "; "+
-			        	spectraList.get(i).ADC2Offset+ "; "+
-			        	spectraList.get(i).ADC3Slope+ "; "+
-			        	spectraList.get(i).ADC3Offset+ "; "+
-			        	spectraList.get(i).Temp1Slope+ "; "+
-			        	spectraList.get(i).Temp1Offset+ "; "+
-			        	spectraList.get(i).Temp2Slope+ "; "+
-			        	spectraList.get(i).Temp2Offset+ "; "+
-			        	spectraList.get(i).Temp3Slope+ "; "+
-			        	spectraList.get(i).Temp3Offset+ "; "+
-			        	spectraList.get(i).Counter1Slope+ "; "+
-			        	spectraList.get(i).Counter1Offset+ "; "+
-			        	spectraList.get(i).Counter2Slope+ "; "+
-			        	spectraList.get(i).Counter2Offset+ "; "+
-			        	spectraList.get(i).monitor+ "; \r\n"
-			        	);
+				
+				int dialogButton = JOptionPane.YES_NO_OPTION;
+	        	int dialogResult = JOptionPane.showConfirmDialog (null, "To continue you have to provide a reference spectrum (.ref). Would you like to load one?" ,"Load reference spectrum", dialogButton);
+	        	if(dialogResult == JOptionPane.YES_OPTION){
+			    	//Create a file chooser
+			        JFileChooser fileDialog = new JFileChooser(ini.lvl0);
+			        
+			        //name of the file chooser window
+			        fileDialog.setDialogTitle("Choose reference spectrum (.ref)");
+			        //only show not hidden files
+			        fileDialog.setFileHidingEnabled(true);			       
+			        //to select single file
+			        fileDialog.setMultiSelectionEnabled(false);
+			        //In response to a button click:
+			        int option = fileDialog.showOpenDialog(null);
+			        
+			        //defined globally
+			        if(option == JFileChooser.APPROVE_OPTION) {
+			        	int i = fileDialog.getSelectedFile().getName().lastIndexOf('.');
+	        			if (!(fileDialog.getSelectedFile().getName().endsWith(".ref"))) {
+			        		System.out.print(fileDialog.getSelectedFile().getName().substring(i+1));
+		      				JOptionPane.showMessageDialog(null, "Provided file is not a reference file (.ref)!" , "Load reference spectrum", JOptionPane.ERROR_MESSAGE);
+			        		return;
+	        			}
+			        	
+			            try {
+			            	System.out.println("load ref spec and u did it!!1");
+							RefSpec = new Spectra(fileDialog.getSelectedFile().getName(),fileDialog.getSelectedFile());
+						} catch (Exception e1) {
+							// TODO Auto-generated catch block
+							e1.printStackTrace();
+						}
+			            
+			            
 			        }
-			        bw.close();
-			        fileOut.close();
-				} catch (FileNotFoundException e1) {
-					// TODO Auto-generated catch block
-					e1.printStackTrace();
-				} catch (IOException e1) {
-					// TODO Auto-generated catch block
-					e1.printStackTrace();
+			    	
+			    } else {
+			    	return;
+			    }
+				
+				JFileChooser fileChooser = new JFileChooser(ini.extractFileFolder); 
+				//name of the file chooser window
+				fileChooser.setDialogTitle("Save Log file (.txt) as:");
+        		if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
+        			File extFile = fileChooser.getSelectedFile();
+        			try {
+	        			if (!(extFile.getName().endsWith(".txt"))) {
+	        				extFile = new File(extFile+".txt");
+	        			}
+      				} catch (Exception e1) {
+      				  JOptionPane.showMessageDialog(null, "Could not create the extract file, maybe you have no writing permissions?" , "Continue evaluation", JOptionPane.INFORMATION_MESSAGE);
+      				  e1.printStackTrace();
+      				}
+					//extract spectra from spectra list and write it into extFile
+					FileOutputStream fileOut;
+					try {
+						fileOut = new FileOutputStream(extFile);
+				    	BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fileOut));
+				    	double progress = 0;
+				    	progressBar.setValue((int) (progress));
+				    	progressBar.setStringPainted(true);
+				    	//write first line
+				        bw.write("Date Time; Lifetime;ADC1; StdADC1; T1; StdT1;T2; StdT2;T3; StdT3;Rn1;Rn2;Rn3;Rn4;ADC2; StdADC2; ADC3; StdADC3; Counter1;Counter2;FluxSlope;FluxOffset;ADC2Slope;ADC2Offset;ADC3Slope;ADC3Offset;Temp1Slope;Temp1Offset;Temp2Slope;Temp2Offset;Temp3Slope;Temp3Offset;Counter1Slope;Counter1Offset;Counter2Slope;Counter2Offset;ID \r\n");
+				        //loop though the selected spectra, see if they need to be flagged
+				        int[] flaggedIdx = new int[spectraList.size()];
+				        for(int i=0; i<spectraList.size(); i++) {
+				        	//set edge of spectrum according to reference (if no edge is set yet)
+				        	spectraList.get(i).calcEdge(RefSpec, ini.thres3, ini.thres4, ini.Edgeoffset);
+				        	progress = (((double) i+1.0)/(spectraList.size())*100.0);
+				        	System.out.println( (progress));
+				        	progressBar.setValue((int) (progress));
+				        	//flag spectra
+				        	if(spectraList.get(i).edge > ini.Edgeoffset+ini.UpperFlagThres || spectraList.get(i).edge < ini.Edgeoffset-ini.LowerFlagThres) {
+				        		//save Spectrum in new subfolder \flagged
+				        		new File(spectraList.get(i).path.getParent()+ "\\flagged").mkdirs();
+				        		File tmpFlagged = new File( spectraList.get(i).path.getParent()+ "\\flagged\\" + spectraList.get(i).name);
+				        		copyFile(spectraList.get(i).path, tmpFlagged);
+				        		flaggedIdx[i]=1;
+				        		System.out.println("copied " + spectraList.get(i).path.getPath() + " to " + tmpFlagged.getPath() );
+				        		continue;
+				        	}
+				        	//TODO: berechnung der slopes und RNs
+				        	bw.write(spectraList.get(i).datetime + "; " +
+				        	spectraList.get(i).LT + "; " +
+				        	spectraList.get(i).ADC1 + "; "+
+				        	spectraList.get(i).ADC1StD + "; "+
+				        	spectraList.get(i).T1 + "; "+
+				        	spectraList.get(i).T1StD + "; "+
+				        	spectraList.get(i).T2 + "; "+
+				        	spectraList.get(i).T2StD + "; "+
+				        	spectraList.get(i).T3 + "; "+
+				        	spectraList.get(i).T3StD + "; "+
+				        	//RN1 in the old Delphi program, counts above the noise threshold (TotalThreshold)
+				        	spectraList.get(i).integrate(ini.thres1, 128) + "; "+			
+				        	//RN2 in the old Delphi, counts inside threshold window (between TotalThres and WindowThreshold)
+				        	spectraList.get(i).integrate(ini.thres1, ini.thres2) + "; "+		
+				        	//RN3 in the old Delphi, counts above the edge
+				        	spectraList.get(i).integrate(spectraList.get(i).edge, 128)+ "; "+		
+				        	//RN4 in the old Delphi
+				        	spectraList.get(i).edge + "; "+		
+				        	spectraList.get(i).ADC2 + "; "+
+				        	spectraList.get(i).ADC2StD + "; "+
+				        	spectraList.get(i).ADC3 + "; "+
+				        	spectraList.get(i).ADC3StD + "; "+
+				        	spectraList.get(i).counter1 + "; "+
+				        	spectraList.get(i).counter2 + "; "+
+				        	spectraList.get(i).fluxslope+ "; "+
+				        	spectraList.get(i).fluxoffset+ "; "+
+				        	spectraList.get(i).ADC2Slope+ "; "+
+				        	spectraList.get(i).ADC2Offset+ "; "+
+				        	spectraList.get(i).ADC3Slope+ "; "+
+				        	spectraList.get(i).ADC3Offset+ "; "+
+				        	spectraList.get(i).Temp1Slope+ "; "+
+				        	spectraList.get(i).Temp1Offset+ "; "+
+				        	spectraList.get(i).Temp2Slope+ "; "+
+				        	spectraList.get(i).Temp2Offset+ "; "+
+				        	spectraList.get(i).Temp3Slope+ "; "+
+				        	spectraList.get(i).Temp3Offset+ "; "+
+				        	spectraList.get(i).Counter1Slope+ "; "+
+				        	spectraList.get(i).Counter1Offset+ "; "+
+				        	spectraList.get(i).Counter2Slope+ "; "+
+				        	spectraList.get(i).Counter2Offset+ "; "+
+				        	spectraList.get(i).monitor+ "; \r\n"
+				        	);
+				        }
+				        bw.close();
+				        fileOut.close();
+				        progressBar.setString("");
+				    	progressBar.setValue(0);
+					} catch (FileNotFoundException e1) {
+						// TODO Auto-generated catch block
+						e1.printStackTrace();
+					} catch (IOException e1) {
+						// TODO Auto-generated catch block
+						e1.printStackTrace();
+					}
+				} else {
+					//user canceled operation
+					return;				
 				}
 			}
 
@@ -987,8 +1034,10 @@ public class RnLog extends JFrame {
 				System.out.println("Evaluator: " + evaluator);
 				//select extract file
 				//Create a file chooser
-		        final JFileChooser actDialog = new JFileChooser();
+		        final JFileChooser actDialog = new JFileChooser(ini.extractFileFolder);
 		        
+		        //name of the file chooser window
+		        actDialog.setDialogTitle("Load Log file (.txt):");
 		        //only show not hidden files
 		        actDialog.setFileHidingEnabled(true);
 		        //to select single file
@@ -1177,8 +1226,10 @@ public class RnLog extends JFrame {
 					System.out.println("Evaluator: " + evaluator);
 					//select extract file
 					//Create a file chooser
-			        final JFileChooser actDialog = new JFileChooser();
+			        final JFileChooser actDialog = new JFileChooser(ini.extractFileFolder);
 			        
+			        //name of the file chooser window
+			        actDialog.setDialogTitle("Load Log file(-s) (.txt):");
 			        //only show not hidden files
 			        actDialog.setFileHidingEnabled(true);
 			        //to select multiple files
@@ -1233,44 +1284,55 @@ public class RnLog extends JFrame {
 				        int dialogButton = JOptionPane.YES_NO_OPTION;
 			        	int dialogResult = JOptionPane.showConfirmDialog (null, "Would you like to save combined and sorted Log file?" ,"Save new Log file?", dialogButton);
 			        	if(dialogResult == JOptionPane.YES_OPTION){
-			        		JFileChooser fileChooser = new JFileChooser();
+			        		JFileChooser fileChooser = new JFileChooser(ini.extractFileFolder);
+			        		//name of the file chooser window
+			        		fileChooser.setDialogTitle("Save combined Log file (.txt) as:");
 			        		
 			        		if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
-			        		  File newExtFile = fileChooser.getSelectedFile();
-			        		  try {
-			        			  String newFilePath = newExtFile.getPath();
-			        			  if (!(newFilePath.substring(newFilePath.length() - 3) == ".txt")) {
-			        				 newExtFile = new File(newFilePath+".txt");
-			        			  }
-			        			  System.out.println("" + newExtFile);
-				        		  newExtFile.createNewFile();
-				      			  FileOutputStream fileOut = new FileOutputStream(newExtFile);
-				      			  BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fileOut));
-				      		      double progress = 0;
-				      		      progressBar.setValue((int) (progress));
-				      		      progressBar.setStringPainted(true);
-				      		      //write first line
-				      		      bw.write("Date Time; Lifetime;ADC1; StdADC1; T1; StdT1;T2; StdT2;T3; StdT3;Rn1;Rn2;Rn3;Rn4;ADC2; StdADC2; ADC3; StdADC3; Counter1;Counter2;FluxSlope;FluxOffset;ADC2Slope;ADC2Offset;ADC3Slope;ADC3Offset;Temp1Slope;Temp1Offset;Temp2Slope;Temp2Offset;Temp3Slope;Temp3Offset;Counter1Slope;Counter1Offset;Counter2Slope;Counter2Offset;ID \r\n");
-				      		      for (int i=0;i<extlines.size();i++) {
-				      		    	  bw.write(extlines.get(i) + "\r\n");
-				      		      }
-				      		        
-				      		      bw.close();
-				      		      fileOut.close();
-			      			} catch (IOException e1) {
+			        			File newExtFile = fileChooser.getSelectedFile();
+			        			try {
+				        			if (!(newExtFile.getName().endsWith(".txt"))) {
+				        				newExtFile = new File(newExtFile+".txt");
+				        			}
+				        			System.out.println("" + newExtFile);
+					        		newExtFile.createNewFile();
+					      			FileOutputStream fileOut = new FileOutputStream(newExtFile);
+					      			BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fileOut));
+					      		    double progress = 0;
+					      		    progressBar.setValue((int) (progress));
+					      		    progressBar.setStringPainted(true);
+					      		    //write first line
+					      		    bw.write("Date Time; Lifetime;ADC1; StdADC1; T1; StdT1;T2; StdT2;T3; StdT3;Rn1;Rn2;Rn3;Rn4;ADC2; StdADC2; ADC3; StdADC3; Counter1;Counter2;FluxSlope;FluxOffset;ADC2Slope;ADC2Offset;ADC3Slope;ADC3Offset;Temp1Slope;Temp1Offset;Temp2Slope;Temp2Offset;Temp3Slope;Temp3Offset;Counter1Slope;Counter1Offset;Counter2Slope;Counter2Offset;ID \r\n");
+					      		    for (int j=0;j<extlines.size();j++) {
+					      		    	bw.write(extlines.get(j) + "\r\n");
+					      		    }
+					      		        
+					      		    bw.close();
+					      		    fileOut.close();
+			      				} catch (IOException e1) {
 			      				  JOptionPane.showMessageDialog(null, "Could not create the extract file, maybe you have no writing permissions?" , "Continue evaluation", JOptionPane.INFORMATION_MESSAGE);
 			      				  e1.printStackTrace();
-			      			}
+			      				}
 			        		  // save to file
 			        		}
 			        	}
 				        
-				        String actFilename = (String) JOptionPane.showInputDialog(null,"Filename (*.act):",
-		                        "Creating ACT File in " +ini.lvl2,
-		                        JOptionPane.PLAIN_MESSAGE, null, null, "activity.act");
-						if(actFilename == null || (actFilename != null && ("".equals(actFilename)))) {
-							    return;
-						}
+			        	JFileChooser fileChooser = new JFileChooser(ini.activityFileFolder);
+		        		//name of the file chooser window
+		        		fileChooser.setDialogTitle("Save activity file (.act) as:");
+		        		
+		        		//creating act file
+						FileOutputStream fileOut;
+		        		File actFile = null;
+		        		if (fileChooser.showSaveDialog(null) == JFileChooser.APPROVE_OPTION) {
+		        			actFile = fileChooser.getSelectedFile();
+		        			if (!(actFile.getName().endsWith(".act"))) {
+		        				actFile = new File(actFile+".act");
+		        			}
+		        		} else {
+		        			return;
+		        		}
+		        		
 						String points = (String) JOptionPane.showInputDialog(null,"Choose 1-5:",
 		                        "Number of points for derivative calculation",
 		                        JOptionPane.PLAIN_MESSAGE, null, null, "1");
@@ -1288,12 +1350,7 @@ public class RnLog extends JFrame {
 							points="1";
 						}
 						      
-				        //creating act file
-						FileOutputStream fileOut;
-						File actFile = new File(ini.lvl2 + "\\" + actFilename);
-						System.out.println("saving activity file at " + actFile.getPath());
-						
-						ArrayList<String> actlines = new ArrayList<String>();
+				        //checking if act file can be created
 						if(extlines.size()<2) {
 				        	JOptionPane.showMessageDialog(null, "Extract file is empty or has no values."/*, JOptionPane.INFORMATION_MESSAGE*/);
 				        	return;
@@ -1411,7 +1468,7 @@ public class RnLog extends JFrame {
 				        	}
 				        }
 				        bw.close();
-				        JOptionPane.showMessageDialog(null, "Successfully created " + actFile.getPath() , "Make Activity File from multiple sources", JOptionPane.INFORMATION_MESSAGE);
+				        JOptionPane.showMessageDialog(null, "Activity file was successfully created!" , "Make Activity File from multiple sources", JOptionPane.INFORMATION_MESSAGE);
 			        } else if (option == JFileChooser.CANCEL_OPTION){
 			        	System.out.println("User cancelled operation. No ACT file was created.");
 			        	return;
@@ -1525,10 +1582,13 @@ public class RnLog extends JFrame {
 	
 	public void chooseSpectraDialog(ChartPanel chartPanel) {
 		//Create a file chooser
-        final JFileChooser fileDialog = new JFileChooser();
+        final JFileChooser fileDialog = new JFileChooser(ini.lvl0);
         
         //only show not hidden files
         fileDialog.setFileHidingEnabled(true);
+        
+        //name of the filechooser window
+        fileDialog.setDialogTitle("Choose Spectra");
         
         //TODO: home directory als start ausw#hlen
         //fileDialog.setCurrentDirectory(System.getProperty("user.dir"));
@@ -1799,21 +1859,46 @@ public class RnLog extends JFrame {
 		if (ini._pathToIniFile == null) {
 			iniFile ini = new iniFile();
 			} 
+		
+		//removing ref spectrum data from the previous runs
+		RefSpec = null;
 		System.out.println("setting the progress bar");
 		progressBar.setStringPainted(true);
 		progressBar.setString("gathering spectra from lvl0 and lvl2");
 		progressBar.setValue(0);
 		String lvl0=  ini.lvl0; //"C:\\Users\\Alessandro\\eclipse-workspace\\AutoRnLog\\lvl0\\";
-		String lvl1=  ini.lvl1; //"C:\\Users\\Alessandro\\eclipse-workspace\\AutoRnLog\\lvl1\\";
-		String lvl2=  ini.lvl2; //"C:\\Users\\Alessandro\\eclipse-workspace\\AutoRnLog\\lvl1\\";
+		String lvl1=  ini.lvl1; 
+		String lvl2=  ini.lvl2; 
 		//compare the files from lvl0 and lvl2, if a file is not in lvl2 but its after the last file in lvl0 -> continue evaluation
 		//otherwise return, because there is no new file to evaluate
 		File lvl0Dir = new File(lvl0);
 		File lvl2Dir = new File(lvl2);
 		ArrayList<File> rawFiles = new ArrayList<File>();// = lvl0Dir.listFiles();
 		ArrayList<File> evFiles = new ArrayList<File>();// = lvl2Dir.listFiles();
-		System.out.println(lvl0Dir + " exists? " + lvl0Dir.exists());
-		System.out.println(lvl2Dir + " exists? " + lvl2Dir.exists());
+		
+
+		if (lvl0Dir.exists()) {
+			System.out.println(lvl0Dir + " exists");
+		} else {
+			JOptionPane.showMessageDialog(null, lvl0Dir + " does not exist. Please give the valid path to the raw data!", "Continue evaluation", JOptionPane.ERROR_MESSAGE);
+			progressBar.setString("");
+			progressBar.setValue(0);
+			return;
+		}
+		
+		if (lvl2Dir.exists()) {
+			System.out.println(lvl2Dir + " exists");
+		} else {
+			boolean folderCreated = lvl2Dir.mkdir();
+			if (folderCreated) {
+				System.out.println(lvl2Dir + " was successfully created");
+			} else {
+				JOptionPane.showMessageDialog(null, lvl2Dir + " cannot be created. Do you have writing permission?", "Continue evaluation", JOptionPane.ERROR_MESSAGE);
+				progressBar.setString("");
+				progressBar.setValue(0);
+				return;
+			}
+		}
 
 		try {
 			for (int i = 0; i < lvl0Dir.listFiles().length; i++) {
@@ -1828,7 +1913,7 @@ public class RnLog extends JFrame {
 						RefSpec = new Spectra(lvl0Dir.listFiles()[i].getName(), lvl0Dir.listFiles()[i]);
 					} catch (Exception e) {
 						System.out.println("could not load reference spectrum");
-						JOptionPane.showMessageDialog(null, "No reference spectrum found. Please create one first." , "Continue evaluation", JOptionPane.INFORMATION_MESSAGE);
+						JOptionPane.showMessageDialog(null, "The reference spectrum found in the lvl0 directory is brocken. Please provide a valid one." , "Continue evaluation", JOptionPane.INFORMATION_MESSAGE);
 						progressBar.setString("");
 						progressBar.setValue(0);
 						e.printStackTrace();
@@ -1836,20 +1921,42 @@ public class RnLog extends JFrame {
 					}
 				}
 			}
+			
+			
 			for (int i = 0; i < lvl2Dir.listFiles().length; i++) {
 				//check if the file is a spectra
 				if (lvl2Dir.listFiles()[i].isFile() && checkFilename(lvl2Dir.listFiles()[i].getName())) {
 					evFiles.add(lvl2Dir.listFiles()[i]);
 				}
 				
-				//search for activity and extract file
-				if (lvl2Dir.listFiles()[i].isFile() && lvl2Dir.listFiles()[i].getName().endsWith(".txt")) {
-					extract = lvl2Dir.listFiles()[i];
-				}
-				if (lvl2Dir.listFiles()[i].isFile() && lvl2Dir.listFiles()[i].getName().endsWith(".act")) {
-					activity = lvl2Dir.listFiles()[i];
-				}
 			}
+			
+			//creating directories for the extract and activity files
+			new File(ini.extractFileFolder).mkdir();
+			new File(ini.activityFileFolder).mkdir();
+			
+			//name convention for extract and activity files
+			String prefixExtract = "extract";
+			String prefixActivity = "activity";
+			
+			//creating new activity and extract files
+			extract = new File(ini.extractFileFolder + "\\" + prefixExtract + ".txt");
+			activity = new File(ini.activityFileFolder + "\\" + prefixActivity + ".act");
+			
+			//checking if such files already exist
+			//cycle until free name is found
+			int i = 1;
+			while (extract.exists()) {
+				extract = new File(ini.extractFileFolder + "\\" + prefixExtract + "_" + i + ".txt");
+				i++;
+			}
+			
+			i = 1;
+			while (activity.exists()) {
+				activity = new File(ini.activityFileFolder + "\\" + prefixActivity + "_" + i + ".act");
+				i++;
+			}
+			
 		} catch (Exception e) {
 			//could not load the spectra
 			JOptionPane.showMessageDialog(null, "Could not read the spectra from lvl0 and lvl2 directories, please specify a correct path in the *.ini file." , "Continue evaluation", JOptionPane.INFORMATION_MESSAGE);

--- a/src/windowManager/Spectra.java
+++ b/src/windowManager/Spectra.java
@@ -642,6 +642,7 @@ public class Spectra {
 		int sum = 0;
 		for(int i=1; i<128; i++) {
 			//(((x)%128)+128)%128 necessary because java does not use the modulu but the remainer, which means it produced negative numbers (out of bounds exception)
+			//System.out.println(this.values[i]+ " " + (((i+shift)%128)+128)%128);
 			sum += this.values[i]*other.values[(((i+shift)%128)+128)%128];
 		}
 		return sum;

--- a/src/windowManager/iniFile.java
+++ b/src/windowManager/iniFile.java
@@ -58,10 +58,12 @@ public class iniFile {
 	//0=false
 	public int fill=0;
 	public String filler = "NaN";
-	//added for continue evaluation button
+	//added default values for continue evaluation button
 	public String lvl0 = "./lvl0/";
 	public String lvl1 = "./lvl1/";
 	public String lvl2 = "./lvl2/";
+	public String extractFileFolder = lvl2;
+	public String activityFileFolder = lvl2;
 	
 	//constructor without arguments if no file was found
 	public iniFile () {
@@ -83,11 +85,10 @@ public class iniFile {
 	
 	public iniFile(File selectedIniFile) {
 		
-		String fileExtention = selectedIniFile.getName().substring(selectedIniFile.getName().length() - 3);
-		
-   		if(fileExtention == "ini") {
+   		if(selectedIniFile.getName().endsWith(".ini")) {
    			System.out.println("You have selected this ini file:\n" +selectedIniFile);
-   			} else {System.out.println("You have to selected ini file!");
+   			} else {
+		        JOptionPane.showMessageDialog(null, "You have to selected ini file (.ini)!", "Error loading ini file", JOptionPane.ERROR_MESSAGE);
    			return;
    			}
    		try {
@@ -97,8 +98,6 @@ public class iniFile {
 			System.out.println("Could not open " + selectedIniFile + ". Maybe it has been deleted?");
 			e.printStackTrace();
 		}
-		
-		
 	}
 	
 	
@@ -117,8 +116,8 @@ public class iniFile {
 		//IMPORTANTIMPORTANTIMPORTANTIMPORTANTIMPORTANTIMPORTANT
 		////////////////////////////////////////////////////////
 		//Add .getParentFile() for exporting, otherwise .jar does not find the ini
-		File[] fList = file.listFiles();
-		//File[] fList = file.getParentFile().listFiles();
+		//File[] fList = file.listFiles();
+		File[] fList = file.getParentFile().listFiles();
 		
 		for (int i = 0; i< fList.length; i++) {
 			if(fList[i].getName().endsWith(".ini")) {
@@ -153,6 +152,10 @@ public class iniFile {
         bufferedReader.close();
         
         this._pathToIniFile = file;
+        
+        //markers for the presence of folder paths
+        boolean isExtFolderPresent = false;
+        boolean isActFolderPresent = false;
         
         //save values in this class
         for (int i=0; i<lines.size(); i++) {
@@ -193,148 +196,96 @@ public class iniFile {
         		case "lvl0": lvl0 = lines.get(i).trim().split("=")[1];break;
         		case "lvl1": lvl1 = lines.get(i).trim().split("=")[1];break;
         		case "lvl2": lvl2 = lines.get(i).trim().split("=")[1];break;
+        		case "extractFileFolder": {extractFileFolder = lines.get(i).trim().split("=")[1];
+        								   isExtFolderPresent =true;break;
+        		}
+        		case "activityFileFolder": {activityFileFolder = lines.get(i).trim().split("=")[1];
+        									isActFolderPresent= true; break;
+        		}
         		default: break;
         	}
+        }
+        //by default if no path for the extract and activity file is given it should be saved in the lvl2 directory
+        if (!isExtFolderPresent) {
+        	extractFileFolder = lvl2;
+        }
+        if (!isActFolderPresent) {
+        	activityFileFolder = lvl2;
         }
 	}
 	
 	public void overwriteIniFile(File file, JTextField tfMonitorID, JTextField tfNoiseThreshold, JTextField tfWindowThreshold, JTextField tfLowerFitThreshold, JTextField tfUpperFitThreshold, JTextField tfLowerFlagThreshold, 
 			JTextField tfUpperFlagThreshold, JTextField tfFluxslope, JTextField tfFluxoffset, JTextField tfSolidangle, JTextField tfDisequilibriumfactor, JTextField tfHoentzsch, JTextField tfInterval, JTextField tfEdgeoffset, JTextField tfIPAdress, 
-			JTextField tfFluxchannel, JTextField tfFiller, JCheckBox chckbxfillup, JTextField tfRawDataPath, JTextField tfAtomaticDataPath, JTextField tfBrowsedDataPath) throws Exception, IOException {
-		if (_pathToIniFile==null) {
-			//no file -> crerate new one
-			System.out.println("no ini file found -> saving new one");
-			try {
-				createNewFile();
-			} catch (Exception e) {
-				JOptionPane.showMessageDialog(null, "No .ini File found and could not create a new one. Maybe you have no writing permission?"/*, JOptionPane.INFORMATION_MESSAGE*/);
-				return;
-			}
-			
-		} else {
+			JTextField tfFluxchannel, JTextField tfFiller, JCheckBox chckbxfillup, JTextField tfRawDataPath, JTextField tfAtomaticDataPath, JTextField tfBrowsedDataPath, JTextField tfextractFileFolder, JTextField tfactivityFileFolder) throws Exception, IOException {
+		
 
-			System.out.println("overwriting existing ini file");
+			
 			//go through every value of the window and check if its the same as in the ini file
 			try {
-				if (!(this.id.equals(tfMonitorID.getText()))) {
-					this.id = tfMonitorID.getText();
-					findAndReplace(file, "id", tfMonitorID.getText());
-				}
-				if (!( Integer.toString(this.thres1).equals( tfNoiseThreshold.getText() ))) {
-					this.thres1 = Integer.parseInt(tfNoiseThreshold.getText());
-					findAndReplace(file, "thres1", tfNoiseThreshold.getText());
-				}
-				if (!( Integer.toString(this.thres2).equals( tfWindowThreshold.getText() ))) {
-					this.thres2 = Integer.parseInt(tfWindowThreshold.getText());
-					findAndReplace(file, "thres2", tfWindowThreshold.getText());
-				}
-				if (!( Integer.toString(this.thres3).equals( tfLowerFitThreshold.getText() ))) {
-					this.thres3 = Integer.parseInt(tfLowerFitThreshold.getText());
-					findAndReplace(file, "thres3", tfLowerFitThreshold.getText());
-				}
-				if (!( Integer.toString(this.thres4).equals( tfUpperFitThreshold.getText() ))) {
-					this.thres4 = Integer.parseInt(tfUpperFitThreshold.getText());
-					findAndReplace(file, "thres4", tfUpperFitThreshold.getText());
-				}
-				/*
-				if (!( Integer.toString(this.thres5).equals( tfLowerFlagThreshold.getText() ))) {
-					this.thres5 = Integer.parseInt(tfLowerFlagThreshold.getText());
-					findAndReplace(file, "thres5", tfLowerFlagThreshold.getText());
-				}
-				if (!( Integer.toString(this.thres6).equals( tfUpperFlagThreshold.getText() ))) {
-					this.thres6 = Integer.parseInt(tfUpperFlagThreshold.getText());
-					findAndReplace(file, "thres6", tfUpperFlagThreshold.getText());
-				}*/
-				if (!( Integer.toString(this.LowerFlagThres).equals( tfLowerFlagThreshold.getText() ))) {
-					this.LowerFlagThres = Integer.parseInt(tfLowerFlagThreshold.getText());
-					findAndReplace(file, "LowerFlagThres", tfLowerFlagThreshold.getText());
-				}
-				if (!( Integer.toString(this.UpperFlagThres).equals( tfUpperFlagThreshold.getText() ))) {
-					this.UpperFlagThres = Integer.parseInt(tfUpperFlagThreshold.getText());
-					findAndReplace(file, "UpperFlagThres", tfUpperFlagThreshold.getText());
-				}
-				/* not used in the old radon program ?
-				if (!( Integer.toString(this.thres7).equals( tfFluxslope.getText() ))) {
-					this.thres7 = Integer.parseInt(tfFluxslope.getText());
-					findAndReplace(file, "thres7", tfFluxslope.getText());
-				}
-				if (!( Integer.toString(this.thres8).equals( tfFluxoffset.getText() ))) {
-					this.thres8 = Integer.parseInt(tfFluxoffset.getText());
-					findAndReplace(file, "thres8", tfFluxoffset.getText());
-				}
-				*/
 				
-				if (!( Double.toString(this.fluxslope).equals( tfFluxslope.getText() ))) {
-					this.fluxslope = Double.parseDouble(tfFluxslope.getText());
-					findAndReplace(file, "fluxslope", tfFluxslope.getText());
-				}
-				if (!( Double.toString(this.fluxoffset).equals( tfFluxoffset.getText() ))) {
-					this.fluxoffset = Double.parseDouble(tfFluxoffset.getText());
-					findAndReplace(file, "fluxoffset", tfFluxoffset.getText());
-				} 
-				if (!( Double.toString(this.solidangle).equals( tfSolidangle.getText() ))) {
-					this.solidangle = Double.parseDouble(tfSolidangle.getText());
-					findAndReplace(file, "solidangle", tfSolidangle.getText());
-				}
-				if (!( Double.toString(this.disequilibrium).equals( tfDisequilibriumfactor.getText() ))) {
-					this.disequilibrium = Double.parseDouble(tfDisequilibriumfactor.getText());
-					findAndReplace(file, "disequilibrium", tfDisequilibriumfactor.getText());
-				} 
-				if (!( Integer.toString(this.Hoen).equals( tfHoentzsch.getText() ))) {
-					this.Hoen = Integer.parseInt(tfHoentzsch.getText());
-					findAndReplace(file, "Hoen", tfHoentzsch.getText());
-				}
-				if (!( Integer.toString(this.invl).equals( tfInterval.getText() ))) {
-					this.invl = Integer.parseInt(tfInterval.getText());
-					findAndReplace(file, "invl", tfInterval.getText());
-				}
-				if (!( Integer.toString(this.Edgeoffset).equals( tfEdgeoffset.getText() ))) {
-					this.Edgeoffset = Integer.parseInt(tfEdgeoffset.getText());
-					findAndReplace(file, "Edgeoffset", tfEdgeoffset.getText());
-				}
-				if (!( this.IP.equals( tfIPAdress.getText() ))) {
-					this.IP = tfIPAdress.getText();
-					findAndReplace(file, "IP", tfIPAdress.getText());
-				}
-				if (!( Integer.toString(this.Fluxchannel).equals( tfFluxchannel.getText() ))) {
-					this.Fluxchannel = Integer.parseInt(tfFluxchannel.getText());
-					findAndReplace(file, "Fluxchannel", tfFluxchannel.getText());
-				}
-				if (!( this.filler.equals( tfFiller.getText() ))) {
-					this.filler = tfFiller.getText();
-					findAndReplace(file, "filler", tfFiller.getText());
-				}
-				if ( this.fill ==0 && chckbxfillup.isSelected() ) {
+				this.id = tfMonitorID.getText();
+				this.thres1 = Integer.parseInt(tfNoiseThreshold.getText());
+				this.thres2 = Integer.parseInt(tfWindowThreshold.getText());
+				this.thres3 = Integer.parseInt(tfLowerFitThreshold.getText());
+				this.thres4 = Integer.parseInt(tfUpperFitThreshold.getText());
+				this.LowerFlagThres = Integer.parseInt(tfLowerFlagThreshold.getText());
+				this.UpperFlagThres = Integer.parseInt(tfUpperFlagThreshold.getText());
+				
+			    /* not used in the old radon program ?
+			    this.thres5 = Integer.parseInt(tfLowerFlagThreshold.getText());
+				this.thres6 = Integer.parseInt(tfUpperFlagThreshold.getText());
+				this.thres7 = Integer.parseInt(tfFluxslope.getText());
+				this.thres8 = Integer.parseInt(tfFluxoffset.getText());
+			    */
+			
+				this.fluxslope = Double.parseDouble(tfFluxslope.getText());
+				this.fluxoffset = Double.parseDouble(tfFluxoffset.getText());
+				this.solidangle = Double.parseDouble(tfSolidangle.getText());
+				this.disequilibrium = Double.parseDouble(tfDisequilibriumfactor.getText());
+				this.Hoen = Integer.parseInt(tfHoentzsch.getText());
+				this.invl = Integer.parseInt(tfInterval.getText());
+				this.Edgeoffset = Integer.parseInt(tfEdgeoffset.getText());
+				this.IP = tfIPAdress.getText();
+				this.Fluxchannel = Integer.parseInt(tfFluxchannel.getText());
+				this.filler = tfFiller.getText();
+			
+				if (chckbxfillup.isSelected()) {
 					this.fill = 1;
-					findAndReplace(file, "fill", "1");
-				}
-				if ( this.fill ==1 && !chckbxfillup.isSelected() ) {
+				} else {
 					this.fill = 0;
-					findAndReplace(file, "fill", "0");
 				}
-				if (!( this.lvl0.equals( tfRawDataPath.getText() ))) {
-					this.lvl0 = tfRawDataPath.getText();
-					findAndReplace(file, "lvl0", tfRawDataPath.getText());
-				}
-				if (!( this.lvl1.equals( tfAtomaticDataPath.getText() ))) {
-					this.lvl1 = tfAtomaticDataPath.getText();
-					findAndReplace(file, "lvl1", tfAtomaticDataPath.getText());
-				}
-				if (!( this.lvl2.equals( tfBrowsedDataPath.getText() ))) {
-					this.lvl2 = tfBrowsedDataPath.getText();
-					findAndReplace(file, "lvl2", tfBrowsedDataPath.getText());
-				}
+				this.lvl0 = tfRawDataPath.getText();
+				this.lvl1 = tfAtomaticDataPath.getText();
+				this.lvl2 = tfBrowsedDataPath.getText();
+				this.extractFileFolder = tfextractFileFolder.getText();
+				this.activityFileFolder = tfactivityFileFolder.getText();
 				
 			} catch (Exception wrongInput) {
+				wrongInput.printStackTrace();
 				JOptionPane.showMessageDialog(null, "File NOT saved. The value entered has the wrong type."/*, JOptionPane.INFORMATION_MESSAGE*/);
 			}
 			
-		}
+			if (_pathToIniFile==null) {
+				//no file -> create new one
+				System.out.println("no ini file found -> saving new one in the folder with RnLog*.*.jar");
+				try {
+					//creating new ini file in the current directory
+					_pathToIniFile = new File("RnLog.ini");
+					createNewFile(_pathToIniFile);
+				} catch (Exception e) {
+					JOptionPane.showMessageDialog(null, "Could not create a new one. Maybe you have no writing permission?"/*, JOptionPane.INFORMATION_MESSAGE*/);
+					e.printStackTrace();
+					return;
+				}
+				
+			} else {
+				System.out.println("overwriting existing ini file");
+				createNewFile(_pathToIniFile);
+			}
 	}
-	
+	/*
 	private void findAndReplace(File file, String variable, String newValue) throws IOException {
 		boolean found = false;
-		System.out.println(variable + " changed to " + newValue);
 		//finds a variable, e.g. disequilibriumfactor, in the ini file and replaces it with a new value
 		//type checking must be done before
 		if(file==null) {
@@ -354,9 +305,10 @@ public class iniFile {
         		lines.add(line);
                 continue;
         	}
-        	if(line.split("=")[0].equals(variable)) {
+        	if(line.replace(" ", "").split("=")[0].equals(variable)) {
         		//found searched line
         		lines.add(variable + "=" + newValue);
+        		System.out.println(variable + " changed to " + newValue);
         		found = true;
         		continue;
         	}
@@ -370,23 +322,26 @@ public class iniFile {
     		bw.write(lines.get(i)  + "\r\n");
     		System.out.println(lines.get(i)  + "\r\n");
     	}
-    	if(!found) bw.write(variable + "=" + newValue);
+    	if(!found) {
+    		bw.write(variable + "=" + newValue);    		
+    		System.out.println(variable + " saved to ini file as " + newValue);
+    	}
     	bw.close();
 	}
-        
-	private void createNewFile () throws Exception {
+     */   
+	private void createNewFile (File pathToIniFile) throws Exception {
 		//create a new ini file out of standard values
 		File newIni = null;
 		try {
-			newIni = new File(RnLog.class.getProtectionDomain().getCodeSource().getLocation().toURI());
-		} catch (URISyntaxException e) {
+			newIni = pathToIniFile;
+		} catch (Exception e) {
 			// TODO Auto-generated catch block
 			e.printStackTrace();
 		}
 		//if(newIni.getAbsolutePath()==null) {
 		//	throw new Exception();
 		//}
-        FileOutputStream fileOut = new FileOutputStream(newIni.getAbsolutePath()+"\\RnLog.ini");
+        FileOutputStream fileOut = new FileOutputStream(pathToIniFile);
     	BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(fileOut));
         bw.write("port=" + port + "\r\n");
         bw.write("thres1=" + thres1 + "\r\n");
@@ -416,6 +371,13 @@ public class iniFile {
         bw.write("Fluxchannel=" + Fluxchannel + "\r\n");
         bw.write("LowerFlagThres=" + LowerFlagThres + "\r\n");
         bw.write("UpperFlagThres=" + UpperFlagThres + "\r\n");
+        bw.write("fill=" + fill + "\r\n");
+        bw.write("filler=" + filler + "\r\n");
+        bw.write("lvl0=" + lvl0 + "\r\n");
+        bw.write("lvl1=" + lvl1 + "\r\n");
+        bw.write("lvl2=" + lvl2 + "\r\n");
+        bw.write("extractFileFolder=" + extractFileFolder + "\r\n");
+        bw.write("activityFileFolder=" + activityFileFolder + "\r\n");
         bw.close();
         fileOut.close();
         this._pathToIniFile = newIni.getAbsoluteFile();


### PR DESCRIPTION
EvalIniDialog changes:
-Filechoosers are now have appropriate name and starting location.
-Option to see and edit the extract and activity files save folder. 
-Loaded ini files are now checked for the .ini extension.

RnLog changes:
-Extract log file option was completely reworked: first user chooses spectra and have to provide ref spec and finally log file saved at the user defined location.
-Filechoosers are now have appropriate name and starting location.
-Loaded files are now checked for the appropriate extension.
-In the continue evaluation method it is now checked if the user defined lvl0 and lvl2 folders exist. If lvl0 does not exist user is notified the method is stoped; if lvl2 does not exist, it is created.
-In the continue evaluation method the extract and activity files are now saved in the folders provided in the ini file. If files with such names already exist there names are extended with an appropriate number.

IniFile changes:
-New variables for the target folders for the extract and activity files are added together with default values (lvl2 folder).
-Method overwriteIniFile was completely reworked and now rewrites the ini file everytime. Consequently the method findAndReplace is no longer needed (it is left in comment). 
-createNewFile method now requires the path to ini file. If none is given new ini file is created in the root directory of the RnLog program.