### PR TITLE
Few fixes

### DIFF
--- a/src/windowManager/EvalIniDialog.java
+++ b/src/windowManager/EvalIniDialog.java
@@ -282,17 +282,14 @@ public class EvalIniDialog extends JDialog {
 		btnBrowse.addActionListener(new ActionListener() {
 			public void actionPerformed(ActionEvent arg0) {
 				
-				//Create a file chooser
+				//home use
 		        final JFileChooser fileDialog = new JFileChooser("C:\\Users\\mgbri\\Desktop\\Ini Files");
-		        
+				//Create a file chooser
+		        //final JFileChooser fileDialog = new JFileChooser();
 		        //name of the filechooser window
 		        fileDialog.setDialogTitle("Choose ini file (.ini):");
 		        //only show not hidden files
-		        fileDialog.setFileHidingEnabled(true);
-		        
-		        //TODO: home directory als start ausw#hlen
-		        //fileDialog.setCurrentDirectory(System.getProperty("user.dir"));
-		        
+		        fileDialog.setFileHidingEnabled(true);		        
 		       
 		        //to select single file
 		        fileDialog.setMultiSelectionEnabled(false);


### PR DESCRIPTION
Changes to RnLog:
-Bug fixed where the first line in the extract file was ignored (NOT the header).
-Now the spectra showed for the manual flagging start with 0 th element.
-To avoid exceeding the range of integer during the 'filling' time difference calculation index i was casted to long.
-new sorting algorithm was implemented for the continueEvaluation2 function.
-tempFileList is purged for the next run. 
-When showing the ref spec the programm starts with 0th index; previously it was causing crush if the show spectra function was used previously.
