### PR TITLE
Some structural changes to RnLog

### DIFF
--- a/src/windowManager/iniFile.java
+++ b/src/windowManager/iniFile.java
@@ -36,7 +36,7 @@ public class iniFile {
 	public int Edgeoffset = 96;
 	public double fluxslope = 1.0;             
 	public double fluxoffset = 0;
-	public double fluxthreshold = 0;
+	public double fluxthreshold = 100;
 	public String id = "1_HD";
 	public String decimalchr = ".";
 	public double solidangle = 0.2650;          


### PR DESCRIPTION
Changes to RnLog:
-Changed command names in the "Analyze" menu like "Continue evaluation" to "Automated evaluation".
-"Create reference..." command now saves new ref spectrum to the location of the source files and NOT to lvl0 folder. During "Automated evaluation" the ref spec is still saved in lvl0 folder.
-"Make extract file" command can now function without directly asking for ref spectrum. First, it checks if all selected files have the edge set, them if ref spectrum was among selected spectra and only then asks for ref spec.
-Lifetime and flux flagging are added to the "Make activity file" command. Now the flagged files are moved to the corresponding  subfolders in the source file destination.
-Old "Make activity file" command is removed.
-Allowed time difference is set to 28 min (1 min before).
-Creation of the extract and activity file in the "Automated  ..." is moved to second part of the evaluation.
-"Automated ..." now creates each time extract file for all spectra in lvl2 folder (except subfolders). Fail safes implemented.

Changes to ini-file:
-Hardcoced value for flux threshold is 100. 

